### PR TITLE
Refactor env loading

### DIFF
--- a/src/data_load/data_loader.py
+++ b/src/data_load/data_loader.py
@@ -79,13 +79,14 @@ def load_data(
 
 def get_data(
     config_path: str = "config.yaml",
-    env_path: str = ".env",
+    env_path: Optional[str] = None,
     data_stage: str = "raw"
 ) -> pd.DataFrame:
     """
-    Main entry: Loads env, config, resolves path, loads data for the requested stage.
+    Main entry: Optionally loads env, then config, resolves path and loads data for the requested stage.
     """
-    load_env(env_path)
+    if env_path:
+        load_env(env_path)
     config = load_config(config_path)
     data_cfg = config.get("data_source", {})
     if data_stage == "raw":

--- a/src/data_load/run.py
+++ b/src/data_load/run.py
@@ -61,7 +61,8 @@ def main(cfg: DictConfig) -> None:
         data_stage = cfg.data_load.data_stage
         df = get_data(
             config_path=config_path,
-            data_stage=data_stage
+            data_stage=data_stage,
+            env_path=None  # already loaded above
         )
         if df.empty:
             logger.warning("Loaded dataframe is empty: %s", resolved_raw_path)


### PR DESCRIPTION
## Summary
- ensure environment file is only loaded once
- make `env_path` optional in `get_data`
- avoid reloading `.env` in data load entry point

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845842f9798832f97acc4e576a15c96