### PR TITLE
Add setup script for Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ The pipeline predicts **opioid abuse disorder** based on anonymized claims data,
 ```bash
 conda env create -f environment.yml
 conda activate mlops-opioid
+./setup.sh  # for Codex sessions
 ```
 
 **Run end-to-end pipeline:**

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -e
+
+# Install python dependencies listed in environment.yml
+pip install \
+    pandas==2.2.3 \
+    numpy==2.2.6 \
+    openpyxl==3.1.5 \
+    pyyaml==6.0.2 \
+    python-dotenv==1.1.0 \
+    pytest==8.3.5 \
+    pytest-dotenv==0.5.2 \
+    scikit-learn==1.6.1 \
+    scipy==1.15.2 \
+    hydra-core \
+    omegaconf \
+    dvc \
+    dvc-s3 \
+    awscli \
+    pytest-cov==6.1.1 \
+    black==25.1.0 \
+    flake8==7.2.0 \
+    mlflow-skinny==2.22.0 \
+    wandb==0.19.11
+
+# Add src to PYTHONPATH for this session
+export PYTHONPATH="$(pwd)/src:$PYTHONPATH"
+
+echo "Environment ready. PYTHONPATH set to include src/"


### PR DESCRIPTION
## Summary
- add `setup.sh` to install packages listed in `environment.yml`
- mention `./setup.sh` in README for Codex sessions

## Testing
- `./setup.sh` *(fails: Could not install packages)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684586eee218832f912bf8c0b6bbefbe