### PR TITLE
Add model path to artifacts config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -147,6 +147,7 @@ artifacts:
   preprocessing_pipeline: models/preprocessing_pipeline.pkl
   splits_dir: data/splits
   processed_dir: data/processed
+  model_path: models/model.pkl
 
 data_validation:
   enabled: true


### PR DESCRIPTION
## Summary
- specify `model_path` in `config.yaml` so training and evaluation share a common model location

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845b83a492c832fb43c3d7386423a56