### PR TITLE
Fix opioid spelling in config and docs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,8 +7,8 @@ main:
   hydra_options: ""     # Add this line for CLI/MLflow runtime overrides
 
 data_source:
-  raw_path: "./data/raw/opiod_raw_data.csv" # Relative to project root
-  processed_path: "./data/processed/opiod_processed_data.csv"
+  raw_path: "./data/raw/opioid_raw_data.csv" # Relative to project root
+  processed_path: "./data/processed/opioid_processed_data.csv"
   type: "csv"
   sheet_name: "Sheet1"       # Only used if type == 'excel'
   delimiter: ","             # Only used if type == 'csv'

--- a/src/preprocess/preprocessing.py
+++ b/src/preprocess/preprocessing.py
@@ -273,7 +273,7 @@ if __name__ == "__main__":
     """
     Quick CLI helper so students can run:
 
-        python -m src.preprocess.preprocessing data/raw/opiod_raw_data.csv config.yaml
+        python -m src.preprocess.preprocessing data/raw/opioid_raw_data.csv config.yaml
 
     and inspect the first few pre-processed rows.
     """


### PR DESCRIPTION
## Summary
- correct `opiod` typos in configuration and example CLI usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845b83d5fe4832f82f36ec78356cc2b