### PR TITLE
Remove leftover print in tests

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -17,10 +17,7 @@ from model.model import (
 )
 
 from evaluation.evaluator import generate_report
-
 import sys
-print("PYTHONPATH:", sys.path)
-
 
 # --- Fixtures for toy data and config ---
 


### PR DESCRIPTION
## Summary
- clean up `test_model.py` by removing PYTHONPATH print

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy, pandas)*

------
https://chatgpt.com/codex/tasks/task_e_6845bb0c9484832faf96496453827453