### PR TITLE
Add model file check

### DIFF
--- a/src/evaluation/evaluator.py
+++ b/src/evaluation/evaluator.py
@@ -255,6 +255,8 @@ def generate_report(
     target: str = config["target"]
 
     # 1. Load trained model
+    if not os.path.isfile(model_path):
+        raise FileNotFoundError(f"Model artifact not found: {model_path}")
     with open(model_path, "rb") as fh:
         model = pickle.load(fh)
 

--- a/src/evaluation/run.py
+++ b/src/evaluation/run.py
@@ -54,7 +54,13 @@ def main(cfg: DictConfig) -> None:
         )
         logger.info("Started WandB run: %s", run_name)
 
-        report = generate_report(cfg_dict)
+        try:
+            report = generate_report(cfg_dict)
+        except FileNotFoundError as e:
+            logger.error("%s", e)
+            if run is not None:
+                run.alert(title="Evaluation Step Error", text=str(e))
+            sys.exit(1)
 
         metrics_flat: dict[str, float] = {}
         for split, metrics in report.items():

--- a/tests/test_generate_report.py
+++ b/tests/test_generate_report.py
@@ -1,0 +1,16 @@
+import os
+import pytest
+from evaluation.evaluator import generate_report
+
+
+def test_generate_report_missing_model(tmp_path):
+    cfg = {
+        "target": "target",
+        "artifacts": {
+            "model_path": str(tmp_path / "missing_model.pkl"),
+            "processed_dir": str(tmp_path / "proc"),
+            "metrics_path": str(tmp_path / "metrics.json"),
+        },
+    }
+    with pytest.raises(FileNotFoundError):
+        generate_report(cfg)


### PR DESCRIPTION
## Summary
- verify model artifact exists before loading
- log missing model error in evaluation runner
- test generate_report missing model path

## Testing
- `pytest tests/test_generate_report.py::test_generate_report_missing_model -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'data_load')*

------
https://chatgpt.com/codex/tasks/task_e_6845b83bcbbc832f8d43a3277e1c349e