### PR TITLE
Remove debug print from model tests

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -19,7 +19,6 @@ from model.model import (
 from evaluation.evaluator import generate_report
 
 import sys
-print("PYTHONPATH:", sys.path)
 
 
 # --- Fixtures for toy data and config ---


### PR DESCRIPTION
## Summary
- clean up `tests/test_model.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `./setup.sh` *(fails to finish due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6845bb04b5e4832fa81da10dc97a2bc5