### PR TITLE
Fix evaluation step bug with WandB ROC/PR curves

### DIFF
--- a/src/evaluation/evaluator.py
+++ b/src/evaluation/evaluator.py
@@ -48,6 +48,8 @@ def evaluate_classification(
     *,
     metrics: Optional[list[str]] = None,
     split: str = "",
+    save_path: Optional[str] = None,
+    log: bool = False,
 ) -> dict[str, float | dict]:
     """Compute metrics for one data split (drops NaN targets)."""
     mask = ~pd.isna(y)
@@ -64,10 +66,12 @@ def evaluate_classification(
         "recall": "Recall (Sensitivity)",
         "sensitivity": "Recall (Sensitivity)",
         "f1": "F1 Score",
+        "f1 score": "F1 Score",
         "roc auc": "ROC AUC",
         "specificity": "Specificity",
         "npv": "Negative Predictive Value (NPV)",
         "negative predictive value": "Negative Predictive Value (NPV)",
+        "negative predictive value (npv)": "Negative Predictive Value (NPV)",
         "confusion matrix": "Confusion Matrix",
     }
     if metrics is None:
@@ -103,6 +107,17 @@ def evaluate_classification(
                 out[m] = float("nan")
         elif m == "Confusion Matrix":
             out[m] = {"tn": int(tn), "fp": int(fp), "fn": int(fn), "tp": int(tp)}
+
+    if save_path:
+        sp = Path(save_path)
+        sp.parent.mkdir(parents=True, exist_ok=True)
+        with open(sp, "w", encoding="utf-8") as fh:
+            json.dump(out, fh, indent=2)
+
+    if log:
+        msg_split = f" ({split})" if split else ""
+        logger.info("Evaluation metrics%s: %s", msg_split, json.dumps(out))
+
     return out
 
 

--- a/src/evaluation/run.py
+++ b/src/evaluation/run.py
@@ -8,6 +8,7 @@ non-NaN samples and the probability vector is at least length 2.
 """
 
 import sys, logging, hashlib, json
+import numpy as np
 from datetime import datetime
 from pathlib import Path
 
@@ -100,9 +101,12 @@ def main(cfg: DictConfig) -> None:
             # ROC & PR curves
             if y_proba is not None and _len_safe(y_proba) == _len_safe(y_true):
                 if _len_safe(y_proba) > 1:  # need >1 point
+                    y_proba_arr = np.asarray(y_proba)
+                    if y_proba_arr.ndim == 1:
+                        y_proba_arr = np.column_stack([1 - y_proba_arr, y_proba_arr])
                     wandb.log({
-                        "roc_curve": wandb.plot.roc_curve(y_true, y_proba),
-                        "pr_curve":  wandb.plot.pr_curve(y_true, y_proba),
+                        "roc_curve": wandb.plot.roc_curve(y_true, y_proba_arr),
+                        "pr_curve":  wandb.plot.pr_curve(y_true, y_proba_arr),
                     })
 
         # ─── Metrics JSON artifact ─────────────────────────────


### PR DESCRIPTION
## Summary
- ensure evaluation step provides proper probability matrix for wandb ROC/PR plotting
- extend evaluator metric aliases and add optional arguments for saving/logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e76231b0832f99284c0f3722608d