### PR TITLE
Add hydra override support for model step

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ dvc pull     # download project data
 python main.py main.steps=all
 # or using MLflow
 mlflow run . -P steps=all
+# override model hyperparameters (Hydra syntax)
+python main.py main.steps=model main.hydra_options='model.decision_tree.params.max_depth=6 model.decision_tree.params.min_samples_split=3'
 ```
 
 **Run inference from any server (after cloning repo and installing dependencies):**

--- a/config.yaml
+++ b/config.yaml
@@ -32,6 +32,7 @@ model:
     save_path: models/decision_tree.pkl
     params:
       max_depth: 4
+      min_samples_split: 2
       random_state: 42
   logistic_regression:
     save_path: models/logistic_regression.pkl

--- a/main.py
+++ b/main.py
@@ -18,7 +18,7 @@ PIPELINE_STEPS = [
 ]
 
 # Only these steps accept Hydra overrides via MLflow parameters
-STEPS_WITH_OVERRIDES = {}
+STEPS_WITH_OVERRIDES = {"model"}
 
 
 @hydra.main(config_name="config", config_path=".", version_base=None)

--- a/src/model/MLproject
+++ b/src/model/MLproject
@@ -9,4 +9,4 @@ entry_points:
         default: ""
         description: Extra Hydra overrides (optional)
     command: >
-      python run.py
+      python run.py ${hydra_options}

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -53,7 +53,7 @@ def minimal_config(tmp_path):
         },
         "model": {
             "active": "decision_tree",
-            "decision_tree": {"params": {"max_depth": 2}}
+            "decision_tree": {"params": {"max_depth": 2, "min_samples_split": 2}}
         },
         "artifacts": {
             "splits_dir": str(tmp_path / "splits"),
@@ -93,8 +93,10 @@ def test_train_model_unsupported_type(Xy):
 def test_train_model_with_params(Xy):
     """train_model passes params to sklearn model."""
     X, y = Xy
-    model = train_model(X, y, "decision_tree", {"max_depth": 1})
+    params = {"max_depth": 1, "min_samples_split": 3}
+    model = train_model(X, y, "decision_tree", params)
     assert hasattr(model, "max_depth") and model.max_depth == 1
+    assert hasattr(model, "min_samples_split") and model.min_samples_split == 3
 
 
 # --- Tests for artifact saving/loading ---


### PR DESCRIPTION
## Summary
- allow CLI overrides for the model step via hydra
- forward overrides from main.py
- document an example in README
- add second hyperparameter `min_samples_split`
- update tests to cover both parameters

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6845f2340f3c832f9948e108a1e2c445