### PR TITLE
Ensure consistent artifact filenames

### DIFF
--- a/src/data_load/run.py
+++ b/src/data_load/run.py
@@ -83,7 +83,7 @@ def main(cfg: DictConfig) -> None:
 
         if cfg.data_load.get("log_artifacts", True):
             raw_art = wandb.Artifact("raw_data", type="dataset")
-            raw_art.add_file(str(resolved_raw_path))
+            raw_art.add_file(str(resolved_raw_path), name="raw_data.csv")
             run.log_artifact(raw_art, aliases=["latest"])
             logger.info("Logged raw data artifact to WandB")
 


### PR DESCRIPTION
## Summary
- name raw data artifact file `raw_data.csv`
- log validated data as `validated_data.csv`
- read `validated_data.csv` in feature generation step

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68475957b1d8832fad069ce2bbefbd3f