### PR TITLE
Add missing json import

### DIFF
--- a/src/features/run.py
+++ b/src/features/run.py
@@ -16,6 +16,7 @@ import wandb
 from omegaconf import DictConfig, OmegaConf
 from dotenv import load_dotenv
 import pandas as pd
+import json
 
 # Ensure project modules are importable when executed via MLflow
 PROJECT_ROOT = Path(__file__).resolve().parents[2]


### PR DESCRIPTION
## Summary
- include missing json import in feature engineering run script

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: pandas)*

------
https://chatgpt.com/codex/tasks/task_e_6847df5de854832f81ebef074b28c273