### PR TITLE
Log splits artifact in model run

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The pipeline predicts **opioid abuse disorder** based on anonymized claims data,
 - Data split (train/valid/test) with stratification
 - Model registry (easily swap DecisionTree, LogisticRegression, RandomForest)
 - Evaluation: accuracy, precision, recall, specificity, F1, ROC AUC, etc.
-- Metrics, models, and pipeline saved as artifacts
+ - Metrics, models, pipeline, and raw data splits saved as artifacts
 
 ### 6. Batch Inference (`src/inference/inferencer.py`)
 - Loads preprocessing and model artifacts

--- a/src/model/run.py
+++ b/src/model/run.py
@@ -141,6 +141,16 @@ def main(cfg: DictConfig) -> None:
                     run.log_artifact(art, aliases=["latest"])
                     logger.info("Logged %s artifact to W&B", art_type)
 
+            # Log raw train/valid/test splits for reproducibility
+            splits_dir = PROJECT_ROOT / cfg.artifacts.get("splits_dir", "data/splits")
+            split_files = [splits_dir / f for f in ["train.csv", "valid.csv", "test.csv"]]
+            if all(f.is_file() for f in split_files):
+                splits_art = wandb.Artifact("splits", type="dataset")
+                for f in split_files:
+                    splits_art.add_file(str(f))
+                run.log_artifact(splits_art, aliases=["latest"])
+                logger.info("Logged splits artifact to W&B")
+
     except Exception as e:
         logger.exception("Model step failed")
         run.alert(title="Model Step Error", text=str(e))


### PR DESCRIPTION
## Summary
- log raw train/valid/test split CSVs as a `splits` artifact
- document that raw data splits are saved as artifacts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `bash setup.sh` *(fails to install packages)*

------
https://chatgpt.com/codex/tasks/task_e_6847e2691298832fbf0457de7a5c9618