### PR TITLE
Use temp dirs for W&B downloads

### DIFF
--- a/src/data_validation/run.py
+++ b/src/data_validation/run.py
@@ -56,8 +56,9 @@ def main(cfg: DictConfig) -> None:
 
         # Load raw data artifact from W&B
         raw_art = run.use_artifact("raw_data:latest")
-        raw_path = raw_art.download()
-        df = pd.read_csv(os.path.join(raw_path, "raw_data.csv"))
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            raw_path = raw_art.download(root=tmp_dir)
+            df = pd.read_csv(os.path.join(raw_path, "raw_data.csv"))
         if df.empty:
             logger.warning("Loaded dataframe is empty.")
 

--- a/src/evaluation/run.py
+++ b/src/evaluation/run.py
@@ -9,6 +9,7 @@ non-NaN samples and the probability vector is at least length 2.
 
 import sys, logging, hashlib, json, os
 import numpy as np
+import tempfile
 from datetime import datetime
 from pathlib import Path
 
@@ -58,36 +59,37 @@ def main(cfg: DictConfig) -> None:
     try:
         # ─── Dataset traceability ───────────────────────────────
         data_art = run.use_artifact("preprocessed_data:latest")
-        data_path = data_art.download()
-        schema_path = PROJECT_ROOT / "artifacts" / f"eval_schema_{run.id[:8]}.json"
-        sample_path = PROJECT_ROOT / "artifacts" / f"eval_sample_{run.id[:8]}.csv"
-        df = pd.read_csv(os.path.join(data_path, "preprocessed_data.csv"))
-        if not df.empty:
-            wandb.summary["eval_data_hash"] = df_hash(df)
-            schema = {c: str(t) for c, t in df.dtypes.items()}
-            wandb.summary["eval_data_schema"] = schema
-            schema_path.parent.mkdir(parents=True, exist_ok=True)
-            json.dump(schema, open(schema_path, "w"), indent=2)
-            df.head(50).to_csv(sample_path, index=False)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            data_path = data_art.download(root=tmp_dir)
+            schema_path = PROJECT_ROOT / "artifacts" / f"eval_schema_{run.id[:8]}.json"
+            sample_path = PROJECT_ROOT / "artifacts" / f"eval_sample_{run.id[:8]}.csv"
+            df = pd.read_csv(os.path.join(data_path, "preprocessed_data.csv"))
+            if not df.empty:
+                wandb.summary["eval_data_hash"] = df_hash(df)
+                schema = {c: str(t) for c, t in df.dtypes.items()}
+                wandb.summary["eval_data_schema"] = schema
+                schema_path.parent.mkdir(parents=True, exist_ok=True)
+                json.dump(schema, open(schema_path, "w"), indent=2)
+                df.head(50).to_csv(sample_path, index=False)
 
-            schema_art = wandb.Artifact(
-                "evaluation_schema", type="schema"
+                schema_art = wandb.Artifact(
+                    "evaluation_schema", type="schema"
+                )
+                schema_art.add_file(str(schema_path))
+                schema_art.add_file(str(sample_path))
+                run.log_artifact(schema_art, aliases=["latest"])
+                if cfg.data_load.get("log_sample_artifacts", True):
+                    wandb.log({"eval_sample_rows": wandb.Table(dataframe=df.head(50))})
+
+            # ─── Metrics and arrays ─────────────────────────────────
+            model_art = run.use_artifact("model:latest")
+            model_dir = model_art.download(root=tmp_dir)
+            model_file = os.path.join(model_dir, "model.pkl")
+            report, y_true, y_pred, y_proba = generate_report(
+                cfg_dict,
+                model_path=model_file,
+                processed_dir=data_path,
             )
-            schema_art.add_file(str(schema_path))
-            schema_art.add_file(str(sample_path))
-            run.log_artifact(schema_art, aliases=["latest"])
-            if cfg.data_load.get("log_sample_artifacts", True):
-                wandb.log({"eval_sample_rows": wandb.Table(dataframe=df.head(50))})
-
-        # ─── Metrics and arrays ─────────────────────────────────
-        model_art = run.use_artifact("model:latest")
-        model_dir = model_art.download()
-        model_file = os.path.join(model_dir, "model.pkl")
-        report, y_true, y_pred, y_proba = generate_report(
-            cfg_dict,
-            model_path=model_file,
-            processed_dir=data_path,
-        )
 
         flat = {}
         for split, metrics in report.items():

--- a/src/features/run.py
+++ b/src/features/run.py
@@ -10,6 +10,7 @@ import logging
 import os
 from datetime import datetime
 from pathlib import Path
+import tempfile
 
 import hydra
 import wandb
@@ -58,8 +59,9 @@ def main(cfg: DictConfig) -> None:
 
         # Load validated data from W&B artifact
         val_art = run.use_artifact("validated_data:latest")
-        val_path = val_art.download()
-        df = pd.read_csv(os.path.join(val_path, "validated_data.csv"))
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            val_path = val_art.download(root=tmp_dir)
+            df = pd.read_csv(os.path.join(val_path, "validated_data.csv"))
         if df.empty:
             logger.warning("Loaded dataframe is empty.")
 

--- a/src/inference/inferencer.py
+++ b/src/inference/inferencer.py
@@ -17,6 +17,7 @@ import pickle
 import sys
 import os
 from pathlib import Path
+import tempfile
 
 import pandas as pd
 import yaml
@@ -69,19 +70,20 @@ def run_inference(
         config: Dict = yaml.safe_load(fh)
 
     if run is not None:
-        model_art = run.use_artifact("model:latest")
-        model_dir = model_art.download()
-        model = _load_pickle(
-            os.path.join(model_dir, "model.pkl"),
-            "model",
-        )
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            model_art = run.use_artifact("model:latest")
+            model_dir = model_art.download(root=tmp_dir)
+            model = _load_pickle(
+                os.path.join(model_dir, "model.pkl"),
+                "model",
+            )
 
-        pp_art = run.use_artifact("preprocessing_pipeline:latest")
-        pp_dir = pp_art.download()
-        pipeline = _load_pickle(
-            os.path.join(pp_dir, "preprocessing_pipeline.pkl"),
-            "preprocessing pipeline",
-        )
+            pp_art = run.use_artifact("preprocessing_pipeline:latest")
+            pp_dir = pp_art.download(root=tmp_dir)
+            pipeline = _load_pickle(
+                os.path.join(pp_dir, "preprocessing_pipeline.pkl"),
+                "preprocessing pipeline",
+            )
     else:
         pp_path = _resolve(
             config.get("artifacts", {}).get(

--- a/src/inference/run.py
+++ b/src/inference/run.py
@@ -14,6 +14,7 @@ import json
 import time
 from datetime import datetime
 from pathlib import Path
+import tempfile
 
 import hydra
 import wandb
@@ -70,11 +71,12 @@ def main(cfg: DictConfig) -> None:
         # Prefer W&B artifact for input data to preserve lineage
         try:
             in_art = run.use_artifact("predictions_input:latest")
-            art_dir = Path(in_art.download())
-            csv_files = list(art_dir.glob("*.csv"))
-            if csv_files:
-                input_path = csv_files[0]
-                logger.info("Using predictions_input artifact: %s", input_path)
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                art_dir = Path(in_art.download(root=tmp_dir))
+                csv_files = list(art_dir.glob("*.csv"))
+                if csv_files:
+                    input_path = csv_files[0]
+                    logger.info("Using predictions_input artifact: %s", input_path)
         except Exception:
             logger.warning(
                 "predictions_input artifact not found; falling back to %s",

--- a/src/preprocess/run.py
+++ b/src/preprocess/run.py
@@ -15,6 +15,7 @@ import hashlib
 import json
 from datetime import datetime
 from pathlib import Path
+import tempfile
 
 import hydra
 import wandb
@@ -71,8 +72,9 @@ def main(cfg: DictConfig) -> None:
 
         # Load engineered data from W&B artifact
         eng_art = run.use_artifact("engineered_data:latest")
-        eng_path = eng_art.download()
-        df = pd.read_csv(os.path.join(eng_path, "engineered_data.csv"))
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            eng_path = eng_art.download(root=tmp_dir)
+            df = pd.read_csv(os.path.join(eng_path, "engineered_data.csv"))
         if df.empty:
             logger.warning("Loaded dataframe is empty.")
         sample_path = PROJECT_ROOT / "artifacts" / "preprocess_sample.csv"


### PR DESCRIPTION
## Summary
- avoid leaving W&B artifact caches behind by downloading into TemporaryDirectory
- apply this to data_validation, feature engineering, preprocessing, model, evaluation, and inference steps

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6848777e374c832f90b92aab1ead6e2a