### PR TITLE
Fix file name detection for preprocessing

### DIFF
--- a/src/preprocess/run.py
+++ b/src/preprocess/run.py
@@ -74,7 +74,9 @@ def main(cfg: DictConfig) -> None:
         eng_art = run.use_artifact("engineered_data:latest")
         with tempfile.TemporaryDirectory() as tmp_dir:
             eng_path = eng_art.download(root=tmp_dir)
-            df = pd.read_csv(os.path.join(eng_path, "engineered_data.csv"))
+            # Determine file name from config in case it was changed
+            csv_name = Path(cfg.data_source.processed_path).name
+            df = pd.read_csv(os.path.join(eng_path, csv_name))
         if df.empty:
             logger.warning("Loaded dataframe is empty.")
         sample_path = PROJECT_ROOT / "artifacts" / "preprocess_sample.csv"


### PR DESCRIPTION
## Summary
- determine the engineered CSV filename from config when running preprocessing

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68487dfc4e94832fa50d9d6f976ba162