### PR TITLE
Refactor pipeline steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository provides a modular, **production-quality** MLOps pipeline for bi
 
 **Phase 1: Modularization, Testing, and Best Practices**
 - Jupyter notebook translated into well-documented, test-driven Python modules
-- End-to-end pipeline: data ingestion, validation, feature engineering, preprocessing, model training, evaluation, and batch inference
+ - End-to-end pipeline: data ingestion, validation, model training (with integrated feature engineering and preprocessing), evaluation, and batch inference
 - Robust configuration via `config.yaml` and reproducibility through explicit artifact management
 - Extensive unit testing with pytest
 - Strict adherence to software engineering and MLOps best practices
@@ -38,10 +38,10 @@ This repository provides a modular, **production-quality** MLOps pipeline for bi
 │   ├── data_load/               # Data ingestion utilities
 │   ├── data_validation/         # Config-driven schema and data validation
 │   ├── evaluation/              # Model evaluation (metrics, confusion matrix, etc.)
-│   ├── features/                # Feature engineering transformers (scikit-learn compatible)
 │   ├── inference/               # Batch inference script
-│   ├── model/                   # End-to-end training and evaluation logic
-│   └── preprocess/              # Preprocessing pipeline assembly
+│   ├── model/                   # Training step with feature engineering & preprocessing
+│   ├── features/                # Feature engineering utilities (used within model step)
+│   └── preprocess/              # Preprocessing utilities (used within model step)
 ├── tests/                       # Unit and integration tests (pytest)
 ```
 
@@ -88,25 +88,18 @@ The pipeline predicts **opioid abuse disorder** based on anonymized claims data,
 - Configurable strictness: `raise` or `warn` on errors
 - Outputs detailed validation reports (JSON)
 
-### 3. Feature Engineering (`src/features/feature_eng.py`)
-- Implements scikit-learn compatible transformers (e.g., clinical risk score)
-- Easily extendable for future feature construction
-
-### 4. Preprocessing Pipeline (`src/preprocess/preprocessing.py`)
-- Modular scikit-learn pipelines
-- Prevents data leakage: pipeline fit **only on train split**
-
-### 5. Model Training and Evaluation (`src/model/model.py`)
+### 3. Model Training, Feature Engineering & Preprocessing (`src/model/model.py`)
+- Performs all feature engineering and preprocessing within the training step
 - Data split (train/valid/test) with stratification
 - Model registry (easily swap DecisionTree, LogisticRegression, RandomForest)
 - Evaluation: accuracy, precision, recall, specificity, F1, ROC AUC, etc.
- - Metrics, models, pipeline, and raw data splits saved as artifacts
+- Metrics, models, pipeline, and raw data splits saved as artifacts
 
-### 6. Batch Inference (`src/inference/inferencer.py`)
+### 4. Batch Inference (`src/inference/inferencer.py`)
 - Loads preprocessing and model artifacts
 - Transforms new data, predicts outcomes, exports CSV
 
-### 7. Unit Testing (`tests/`)
+### 5. Unit Testing (`tests/`)
 - Full pytest suite for each module
 - Sample/mock data provided for CI/CD
 

--- a/main.py
+++ b/main.py
@@ -12,8 +12,6 @@ load_dotenv()  # Only for secrets
 PIPELINE_STEPS = [
     "data_load",
     "data_validation",
-    "features",
-    "preprocess",
     "model",
     "evaluation",
     "inference",

--- a/src/features/run.py
+++ b/src/features/run.py
@@ -1,8 +1,9 @@
 """
 feature_eng/run.py
 
-MLflow-compatible feature engineering step with Hydra config, W&B logging,
-and robust error handling.
+MLflow-compatible feature engineering step with Hydra config and W&B logging.
+While you can execute this module independently, in the standard workflow its
+transformers are called from the model step rather than as a separate stage.
 """
 
 import sys

--- a/src/model/model.py
+++ b/src/model/model.py
@@ -3,6 +3,7 @@ model.py
 
 Leakage-proof, end-to-end MLOps pipeline:
 - Splits raw data first
+- Performs feature engineering and preprocessing inside this step
 - Fits preprocessing pipeline ONLY on train split, applies to valid/test
 - Trains model, evaluates, and saves model and preprocessing artifacts
 """

--- a/src/preprocess/run.py
+++ b/src/preprocess/run.py
@@ -2,6 +2,8 @@
 preprocess/run.py
 
 MLflow-compatible preprocessing step with Hydra config and W&B logging.
+This module can still be run on its own, but in the default pipeline the
+preprocessing logic is triggered from within the model step.
 Builds the preprocessing pipeline defined in ``config.yaml`` and saves it
 as a pickle artifact for downstream stages.
 Logs input data hash, schema, sample, and feature stats for reproducibility and best MLOps practices.


### PR DESCRIPTION
## Summary
- remove `features` and `preprocess` from `PIPELINE_STEPS`
- clarify repository structure and pipeline documentation
- note in docs that feature engineering and preprocessing run inside the model step
- update step documentation in feature and preprocess modules
- improve model step docstring

## Testing
- `pip install pandas numpy scikit-learn pyyaml python-dotenv pytest pytest-dotenv`
- `export PYTHONPATH="$(pwd)/src:$PYTHONPATH"`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684890edc69c832f97bb0893808ce5e1