### PR TITLE
Add env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+WANDB_PROJECT=your-wandb-project
+WANDB_ENTITY=your-wandb-entity

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ pip-wheel-metadata/
 .env
 .env.*
 *.env
+!/.env.example
 
 # Logs
 logs/

--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ conda activate mlops_project
 ./setup.sh  # install all dependencies for testing
 dvc pull     # download project data
 wandb login  # authenticate with Weights & Biases
-export WANDB_PROJECT=opioid_mlops_project
-export WANDB_ENTITY=<your-wandb-entity>
+cp .env.example .env  # create local credentials file
+# Edit `.env` and set WANDB_PROJECT and WANDB_ENTITY
 ```
 
 **Run end-to-end pipeline:**


### PR DESCRIPTION
## Summary
- provide `.env.example` for W&B configuration
- mention copying it in README
- track example in repo via `.gitignore` exception

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6848b722f6c4832fa9d3d4323178bb83